### PR TITLE
Correct `Send` and `Sync` bounds

### DIFF
--- a/src/ringbuffer/mod.rs
+++ b/src/ringbuffer/mod.rs
@@ -112,8 +112,8 @@ pub struct RingBuffer<T> {
 
 // these implementations are required to access a ringbuffer in a separate
 // lifetime and thread using only a wrapping Arc.
-unsafe impl<T> marker::Send for RingBuffer<T> {}
-unsafe impl<T> marker::Sync for RingBuffer<T> {}
+unsafe impl<T> marker::Send for RingBuffer<T> where T: Send {}
+unsafe impl<T> marker::Sync for RingBuffer<T> where T: Send {}
 
 impl<T> Default for RingBuffer<T> {
 	// this is convenient so we don't have to create 0 for atomics


### PR DESCRIPTION
This is necessary for thread safety, as otherwise you could, e.g., put a `Rc<Cell<T>>` or `&Cell<T>` in here and send it across threads (which is not safe).  I believe, however, that `Sync` only requires `Send`, not `Sync`, as the ring buffer already performs adequate synchronization during `get` and you do not hand out shared references to the items in the queue.
