### PR TITLE
Fix UB in ring buffer implementation

### DIFF
--- a/src/ringbuffer/mod.rs
+++ b/src/ringbuffer/mod.rs
@@ -135,16 +135,7 @@ impl<T> Default for RingBuffer<T> {
 	// this is convenient so we don't have to create 0 for atomics
 	// and empty arrays with every constructor call.
 	fn default() -> RingBuffer<T> {
-		RingBuffer{
-			queue:     ATOMIC_USIZE_INIT,
-			_padding0: [0;8],
-			dequeue:   ATOMIC_USIZE_INIT,
-			_padding1: [0;8],
-			disposed:  ATOMIC_BOOL_INIT,
-			_padding2: [0;8],
-			mask: 	   0,
-			positions: vec![],
-		}
+        RingBuffer::new(0)
 	}
 }
 
@@ -190,7 +181,6 @@ impl<T> RingBuffer<T> {
                 _padding2: [0;8],
                 mask: calculated_capacity-1,
                 positions: positions,
-                ..Default::default()
             }
         }
 	}

--- a/src/ringbuffer/mod.rs
+++ b/src/ringbuffer/mod.rs
@@ -272,7 +272,7 @@ impl<T> RingBuffer<T> {
 
             if i == 10000 {
                 i = 0;
-                //yield_now();
+                yield_now();
             } else {
                 i += 1;
             }

--- a/src/ringbuffer/mod.rs
+++ b/src/ringbuffer/mod.rs
@@ -94,7 +94,8 @@ impl<T> Node<T> {
 /// RingBuffer is a threadsafe MPMC queue that's statically-sized.
 /// Puts are blocked on a full queue and gets are blocked on an empty
 /// queue.  In either case, calling dispose will free any blocked threads
-/// and return an error. 
+/// and return an error.
+#[repr(C)]
 pub struct RingBuffer<T> {
 	queue: 	   AtomicUsize,
 	// padding is here to ensure that queue and dequeue end on different

--- a/src/ringbuffer/mod.rs
+++ b/src/ringbuffer/mod.rs
@@ -465,6 +465,7 @@ mod rbtest {
         } else {
             run( |rb| b.iter( || {
                 let rb = rb.clone();
+                rb.put(1);
             }));
         }
 	}


### PR DESCRIPTION
The current implementation of RingBuffer is (I'm pretty sure) aliasing `&mut`s in the implementation of `put`.  This is leading to undefined behavior which manifests as the benchmark frequently not finishing.  I fixed this by moving the `UnsafeCell` to the actual ring buffer entry instead of the entire vector.  In the process, I also got rid of the `Option` where the item data was (we don't really need it because we already know which elements of the vector matter, and this will lead to the elements in the ring buffer taking up less space), made the test last a more intelligent amount of time, and fixed arithmetic to be more explicit about expectations on overflow.
